### PR TITLE
Making docker registry optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: 'docker login password'
     required: false
   docker-registry:  # Docker registry
-    description: 'docker registry'
+    description: 'docker registry, defaults to DockerHub'
     required: false
 
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ git config --global user.name ${GITHUB_USERNAME}
 git config --global user.password ${GITHUB_PASSWORD}
 
 COMMAND=$1
-if [[ -z "${2}" || -z "${3}" || -z "${4}" ]]; then
+if [[ -z "${2}" || -z "${3}" ]]; then
   echo "One or more variables are not defined, will only run command"
 else
   DOCKER_USERNAME=$2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,8 @@ else
   DOCKER_USERNAME=$2
   DOCKER_PASSWORD=$3
   DOCKER_REGISTRY=$4
-  echo "Running docker login into ${DOCKER_REGISTRY}"
+  echo "Running docker login"
+  [ -z "$DOCKER_REGISTRY" ] || echo "Using custom registry: ${DOCKER_REGISTRY}"
   echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin ${DOCKER_REGISTRY}
 fi
 


### PR DESCRIPTION
I thought you could find this on useful. I could also benefit from this one out-of-the-box.

Docker defaults to DockerHub by default, which is very convenient for 99 % of the people. Requiring a registry to be specified can be baffling as few people actually know the name DockerHub uses internally due to having never spelt it before.