### PR TITLE
Add updated link to download sbt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN set -x \
   && apk --update add --no-cache --virtual .build-deps curl \
   && SBT_VER="1.3.8" \
   && ESUM="27b2ed49758011fefc1bd05e1f4156544d60673e082277186fdd33b6f55d995d" \
-  && SBT_URL="https://piccolo.link/sbt-${SBT_VER}.tgz" \
+  # && SBT_URL="https://piccolo.link/sbt-${SBT_VER}.tgz" \
+  && SBT_URL="https://github.com/sbt/sbt/releases/download/v${SBT_VER}/sbt-${SBT_VER}.tgz" \
   && apk add shadow \
   && apk add bash \
   && apk add openssh \


### PR DESCRIPTION
Since `piccolo.link` had several issues recently, the sbt download link
was updated to the actual place where the packages are stored.